### PR TITLE
Add domain to all log entries.

### DIFF
--- a/app/models/concerns/lets_encrypt/certificate_issuable.rb
+++ b/app/models/concerns/lets_encrypt/certificate_issuable.rb
@@ -10,7 +10,7 @@ module LetsEncrypt
       logger.info "Getting certificate for #{domain}"
       create_certificate
       # rubocop:disable Metrics/LineLength
-      logger.info "Certificate issued (expires on #{expires_at}, will renew after #{renew_after})"
+      logger.info "Certificate issued for #{domain} (expires on #{expires_at}, will renew after #{renew_after})"
       # rubocop:enable Metrics/LineLength
       true
     end

--- a/app/models/concerns/lets_encrypt/certificate_verifiable.rb
+++ b/app/models/concerns/lets_encrypt/certificate_verifiable.rb
@@ -37,7 +37,7 @@ module LetsEncrypt
       until @challenge.status != 'pending'
         checks += 1
         if checks > 30
-          logger.info 'Status remained at pending for 30 checks'
+          logger.info "#{domain}: Status remained at pending for 30 checks"
           return false
         end
         sleep 1
@@ -47,7 +47,7 @@ module LetsEncrypt
 
     def check_verify_status
       unless @challenge.status == 'valid'
-        logger.info "Status was not valid (was: #{@challenge.status})"
+        logger.info "#{domain}: Status was not valid (was: #{@challenge.status})"
         return false
       end
 
@@ -58,11 +58,11 @@ module LetsEncrypt
       @retries ||= 0
       if e.is_a?(Acme::Client::Error::BadNonce) && @retries < 5
         @retries += 1
-        logger.info "Bad nounce encountered. Retrying (#{@retries} of 5 attempts)"
+        logger.info "#{domain}: Bad nounce encountered. Retrying (#{@retries} of 5 attempts)"
         sleep 1
         verify
       else
-        logger.info "Error: #{e.class} (#{e.message})"
+        logger.info "#{domain}: Error: #{e.class} (#{e.message})"
         return false
       end
     end


### PR DESCRIPTION
Hi!

I have an installation of thousands of domains and I have found that I need to have the specific domain in the log entries for troubleshooting. This PR adds the domain to all log entries.

This has been accepted into the upstream gem: https://github.com/elct9620/rails-letsencrypt/commit/ea6923860391b2d5a9f02eda875eff37ad3adf6d

Thanks!